### PR TITLE
Add RSS-feed for blog posts

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -21,6 +21,7 @@ module.exports = {
         link: '/imprint'
       }
     ],
+    siteUrl: 'https://hiai.de',
   },
   mapping: {
     'MarkdownRemark.frontmatter.author': 'AuthorsYaml',
@@ -77,6 +78,48 @@ module.exports = {
     'gatsby-plugin-sass',
     'gatsby-plugin-recaptcha',
     'gatsby-plugin-sharp',
+    {
+      resolve: 'gatsby-plugin-feed',
+      options: {
+        feeds: [
+          {
+            serialize: ({ query: { site, allMarkdownRemark } }) => {
+              return allMarkdownRemark.edges.map(edge => {
+                const url = `${site.siteMetadata.siteUrl}/blog${edge.node.fields.slug}`
+
+                return Object.assign({}, edge.node.frontmatter, {
+                  description: edge.node.excerpt,
+                  date: edge.node.frontmatter.date,
+                  url,
+                  guid: url,
+                  custom_elements: [{ "content:encoded": edge.node.html }],
+                })
+              })
+            },
+            query: `
+              {
+                allMarkdownRemark(
+                  sort: { order: DESC, fields: [frontmatter___date] },
+                ) {
+                  edges {
+                    node {
+                      excerpt
+                      html
+                      fields { slug }
+                      frontmatter {
+                        title
+                        date
+                      }
+                    }
+                  }
+                }
+              }
+            `,
+            output: '/blog.xml',
+          }
+        ]
+      }
+    },
     {
       resolve: 'gatsby-plugin-manifest',
       options: {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "bootstrap": "^4.4.1",
     "gatsby": "^2.18.4",
     "gatsby-image": "^2.2.34",
+    "gatsby-plugin-feed": "^2.5.14",
     "gatsby-plugin-manifest": "^2.2.30",
     "gatsby-plugin-netlify-cms": "^4.1.33",
     "gatsby-plugin-offline": "^3.0.24",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { graphql, Link } from 'gatsby'
 import Img from 'gatsby-image'
 import { Card, Container, Row, Col } from 'react-bootstrap'
+import { FaRss } from 'react-icons/fa'
 import SEO from '../components/seo'
 import Layout from '../components/layout'
 
@@ -82,6 +83,12 @@ const BlogPage = ({ data }) => {
       
       <Container>
         { chunks.map((x, index) => <BlogRow key={`Row_${index}`} nodes={x} />)}
+
+        <Row>
+          <Col className="pb-3">
+            <a href="/blog.xml"><FaRss /> RSS feed</a>
+          </Col>
+        </Row>
       </Container>
     </Layout>
   )


### PR DESCRIPTION
Closes #8 

In this, we use the plugin `gatsby-plugin-feed` to automatically generate an RSS-feed from the Markdown-files:

https://www.gatsbyjs.com/plugins/gatsby-plugin-feed/

We need to override the default `serialize`-function of this plugin to add the `/blog` to the URL of the blog posts. The query was taken from the documentation as-is. The resulting feed is saved as `/blog.xml`.

Note that the feed is only regenerated during a build, not during development. To inspect any changes, run `npm run build` before running `npm start`.